### PR TITLE
gentest: src/cli/gentest/tests/test_cli.py refactor

### DIFF
--- a/src/cli/gentest/tests/test_cli.py
+++ b/src/cli/gentest/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for the gentest CLI command."""
 
+import pytest
 from click.testing import CliRunner
 
 from cli.gentest.cli import generate
@@ -8,113 +9,100 @@ from cli.pytest_commands.fill import fill
 from ethereum_test_base_types import Account
 from ethereum_test_tools import Environment, Storage, Transaction
 
+transactions_by_type = {
+    0: {
+        "environment": Environment(
+            fee_recipient="0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            gas_limit=9916577,
+            number=9974504,
+            timestamp=1588257377,
+            difficulty=2315196811272822,
+            parent_ommers_hash="0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+            extra_data=b"\x00",
+        ),
+        "pre_state": {
+            "0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c": Account(
+                nonce=6038603, balance=23760714652307793035, code=b"", storage=Storage(root={})
+            ),
+            "0x8a4a4d396a06cba2a7a4a73245991de40cdec289": Account(
+                nonce=2, balance=816540000000000000, code=b"", storage=Storage(root={})
+            ),
+            "0xc6d96786477f82491bfead8f00b8294688f77abc": Account(
+                nonce=25, balance=29020266497911578313, code=b"", storage=Storage(root={})
+            ),
+        },
+        "transaction": Transaction(
+            ty=0,
+            chain_id=1,
+            nonce=2,
+            gas_price=10000000000,
+            gas_limit=21000,
+            to="0xc6d96786477f82491bfead8f00b8294688f77abc",
+            value=668250000000000000,
+            data=b"",
+            v=38,
+            r=57233334052658009540326312124836763247359579695589124499839562829147086216092,
+            s=49687643984819828983661675232336138386174947240467726918882054280625462464348,
+            sender="0x8a4a4d396a06cba2a7a4a73245991de40cdec289",
+        ),
+    },
+    2: {
+        "environment": Environment(
+            fee_recipient="0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            gas_limit=30172625,
+            number=21758000,
+            timestamp=1738489319,
+            parent_ommers_hash="0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+            extra_data=b"\x00",
+        ),
+        "pre_state": {
+            "0x24d6c74d811cfde65995ed26fd08af445f8aab06": Account(
+                nonce=1011, balance=139840767390685635650, code=b"", storage=Storage(root={})
+            ),
+            "0xd5fbda4c79f38920159fe5f22df9655fde292d47": Account(
+                nonce=553563, balance=162510989019530720334, code=b"", storage=Storage(root={})
+            ),
+            "0xe2e29f9a85cfecb9cdaa83a81c7aa2792f24d93f": Account(
+                nonce=104, balance=553317651330968100, code=b"", storage=Storage(root={})
+            ),
+        },
+        "transaction": Transaction(
+            ty=2,
+            chain_id=1,
+            nonce=553563,
+            max_priority_fee_per_gas=1900000,
+            max_fee_per_gas=3992652948,
+            gas_limit=63000,
+            to="0xe2e29f9a85cfecb9cdaa83a81c7aa2792f24d93f",
+            value=221305417266040400,
+            v=1,
+            r=23565967349511399087318407428036702220029523660288023156323795583373026415631,
+            s=9175853102116430015855393834807954374677057556696757715994220939907579927771,
+            sender="0xd5fbda4c79f38920159fe5f22df9655fde292d47",
+        ),
+    },
+}
 
-def test_type_0_tx(tmp_path, monkeypatch):
-    """Generates a test case for a legacy transaction."""
+
+@pytest.fixture
+def transaction_hash(tx_type: int) -> str:  # noqa: D103
+    return str(transactions_by_type[tx_type]["transaction"].hash)  # type: ignore
+
+
+@pytest.mark.parametrize("tx_type", list(transactions_by_type.keys()))
+def test_tx_type(tmp_path, monkeypatch, tx_type, transaction_hash):
+    """Generates a test case for any transaction type."""
     ## Arrange ##
-
     # This test is run in a CI environment, where connection to a node could be
     # unreliable. Therefore, we mock the RPC request to avoid any network issues.
     # This is done by patching the `get_context` method of the `StateTestProvider`.
     runner = CliRunner()
-    transaction_hash = "0xa41f343be7a150b740e5c939fa4d89f3a2850dbe21715df96b612fc20d1906be"
-    output_file = str(tmp_path / "gentest_type_0.py")
+    output_file = str(tmp_path / f"gentest_type_{tx_type}.py")
+
+    tx = transactions_by_type[tx_type]
 
     def get_mock_context(self: StateTestProvider) -> dict:
-        return {
-            "environment": Environment(
-                fee_recipient="0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
-                gas_limit=9916577,
-                number=9974504,
-                timestamp=1588257377,
-                difficulty=2315196811272822,
-                parent_ommers_hash="0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-                extra_data=b"\x00",
-            ),
-            "pre_state": {
-                "0x5a0b54d5dc17e0aadc383d2db43b0a0d3e029c4c": Account(
-                    nonce=6038603, balance=23760714652307793035, code=b"", storage=Storage(root={})
-                ),
-                "0x8a4a4d396a06cba2a7a4a73245991de40cdec289": Account(
-                    nonce=2, balance=816540000000000000, code=b"", storage=Storage(root={})
-                ),
-                "0xc6d96786477f82491bfead8f00b8294688f77abc": Account(
-                    nonce=25, balance=29020266497911578313, code=b"", storage=Storage(root={})
-                ),
-            },
-            "transaction": Transaction(
-                ty=0,
-                chain_id=1,
-                nonce=2,
-                gas_price=10000000000,
-                gas_limit=21000,
-                to="0xc6d96786477f82491bfead8f00b8294688f77abc",
-                value=668250000000000000,
-                data=b"",
-                v=38,
-                r=57233334052658009540326312124836763247359579695589124499839562829147086216092,
-                s=49687643984819828983661675232336138386174947240467726918882054280625462464348,
-                sender="0x8a4a4d396a06cba2a7a4a73245991de40cdec289",
-            ),
-            "tx_hash": transaction_hash,
-        }
-
-    monkeypatch.setattr(StateTestProvider, "get_context", get_mock_context)
-
-    ## Generate ##
-    gentest_result = runner.invoke(generate, [transaction_hash, output_file])
-    assert gentest_result.exit_code == 0
-
-    ## Fill ##
-    fill_result = runner.invoke(fill, ["-c", "pytest.ini", "--skip-evm-dump", output_file])
-    assert fill_result.exit_code == 0
-
-
-def test_type_2_tx(tmp_path, monkeypatch):
-    """Generates a test case for a type 2 (EIP-1559) transaction."""
-    ## Arrange ##
-
-    runner = CliRunner()
-    transaction_hash = "0xec968359e7823c73d3fb8700926ba150a229a513318c80eef5f293891fc37ff7"
-    output_file = str(tmp_path / "gentest_type_2.py")
-
-    def get_mock_context(self: StateTestProvider) -> dict:
-        return {
-            "environment": Environment(
-                fee_recipient="0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
-                gas_limit=30172625,
-                number=21758000,
-                timestamp=1738489319,
-                parent_ommers_hash="0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-                extra_data=b"\x00",
-            ),
-            "pre_state": {
-                "0x24d6c74d811cfde65995ed26fd08af445f8aab06": Account(
-                    nonce=1011, balance=139840767390685635650, code=b"", storage=Storage(root={})
-                ),
-                "0xd5fbda4c79f38920159fe5f22df9655fde292d47": Account(
-                    nonce=553563, balance=162510989019530720334, code=b"", storage=Storage(root={})
-                ),
-                "0xe2e29f9a85cfecb9cdaa83a81c7aa2792f24d93f": Account(
-                    nonce=104, balance=553317651330968100, code=b"", storage=Storage(root={})
-                ),
-            },
-            "transaction": Transaction(
-                ty=2,
-                chain_id=1,
-                nonce=553563,
-                max_priority_fee_per_gas=1900000,
-                max_fee_per_gas=3992652948,
-                gas_limit=63000,
-                to="0xe2e29f9a85cfecb9cdaa83a81c7aa2792f24d93f",
-                value=221305417266040400,
-                v=1,
-                r=23565967349511399087318407428036702220029523660288023156323795583373026415631,
-                s=9175853102116430015855393834807954374677057556696757715994220939907579927771,
-                sender="0xd5fbda4c79f38920159fe5f22df9655fde292d47",
-            ),
-            "tx_hash": transaction_hash,
-        }
+        return tx
 
     monkeypatch.setattr(StateTestProvider, "get_context", get_mock_context)
 

--- a/src/ethereum_test_rpc/types.py
+++ b/src/ethereum_test_rpc/types.py
@@ -1,9 +1,9 @@
 """Types used in the RPC module for `eth` and `engine` namespaces' requests."""
 
 from enum import Enum
-from typing import List
+from typing import Any, List
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from ethereum_test_base_types import Address, Bytes, CamelModel, Hash, HexNumber
 from ethereum_test_fixtures.blockchain import FixtureExecutionPayload
@@ -35,6 +35,19 @@ class TransactionByHashResponse(Transaction):
     transaction_hash: Hash = Field(..., alias="hash")
     from_address: Address = Field(..., alias="from")
     to_address: Address | None = Field(..., alias="to")
+
+    @model_validator(mode="before")
+    @classmethod
+    def adapt_clients_response(cls, data: Any) -> Any:
+        """
+        Perform modifications necessary to adapt the response returned by clients
+        so it can be parsed by our model.
+        """
+        if isinstance(data, dict):
+            if "gasPrice" in data and "maxFeePerGas" in data:
+                # Keep only one of the gas price fields.
+                del data["gasPrice"]
+        return data
 
 
 class ForkchoiceState(CamelModel):

--- a/src/ethereum_test_rpc/types.py
+++ b/src/ethereum_test_rpc/types.py
@@ -3,7 +3,7 @@
 from enum import Enum
 from typing import Any, List
 
-from pydantic import Field, model_validator
+from pydantic import AliasChoices, Field, model_validator
 
 from ethereum_test_base_types import Address, Bytes, CamelModel, Hash, HexNumber
 from ethereum_test_fixtures.blockchain import FixtureExecutionPayload
@@ -37,6 +37,8 @@ class TransactionByHashResponse(Transaction):
     from_address: Address = Field(..., alias="from")
     to_address: Address | None = Field(..., alias="to")
 
+    v: HexNumber | None = Field(None, validation_alias=AliasChoices("v", "yParity"))
+
     @model_validator(mode="before")
     @classmethod
     def adapt_clients_response(cls, data: Any) -> Any:
@@ -48,10 +50,6 @@ class TransactionByHashResponse(Transaction):
             if "gasPrice" in data and "maxFeePerGas" in data:
                 # Keep only one of the gas price fields.
                 del data["gasPrice"]
-            if "yParity" in data:
-                # Rename yParity to v.
-                data["v"] = data["yParity"]
-                del data["yParity"]
         return data
 
     def model_post_init(self, __context):

--- a/src/ethereum_test_types/types.py
+++ b/src/ethereum_test_types/types.py
@@ -13,6 +13,7 @@ from ethereum.frontier.fork_types import Address as FrontierAddress
 from ethereum.frontier.state import State, set_account, set_storage, state_root
 from ethereum_types.numeric import U256, Bytes32, Uint
 from pydantic import (
+    AliasChoices,
     BaseModel,
     ConfigDict,
     Field,
@@ -436,7 +437,7 @@ class AuthorizationTupleGeneric(CamelModel, Generic[NumberBoundTypeVar]):
     address: Address
     nonce: List[NumberBoundTypeVar] | NumberBoundTypeVar = Field(0)  # type: ignore
 
-    v: NumberBoundTypeVar = Field(0)  # type: ignore
+    v: NumberBoundTypeVar = Field(0, validation_alias=AliasChoices("v", "yParity"))  # type: ignore
     r: NumberBoundTypeVar = Field(0)  # type: ignore
     s: NumberBoundTypeVar = Field(0)  # type: ignore
 


### PR DESCRIPTION
## 🗒️ Description

Refactor the gentests to pytestify them a bit.

One thing I think we should do is, instead of using the `Transaction`, `Environment`, `Account`, etc, classes, we should just do plain JSON here, and use the field names that are actually returned by the client's rpc when calling it directly, because I think this would help catch any parsing issues beforehand.

Let me know if this makes sense to you.